### PR TITLE
moving note to top of page

### DIFF
--- a/artisan_roles/index.md
+++ b/artisan_roles/index.md
@@ -5,6 +5,8 @@ title: Guild Artisan Personas
 
 If you're asking 'Why?', check out the [value stories](value_stories.html).
 
+> The time frame denoted in parentheses is an average number of years spent at that level
+
 Pre Requisites Apprentice
 -------------------------
 As a **prospective Apprentice**\\
@@ -97,6 +99,3 @@ I should exhibit the following behaviors:
 </ul>
 So that I can maintain and grow my role as a **Master Craftsman**
 
-Notes
------
-The time frame denoted in parentheses is an average number of years spent at that level


### PR DESCRIPTION
I have received multiple questions concerning the number of years (listed after each role title)... I explained and then the note at the bottom answered the same question... I moved it to the top in order for earlier viewing.