### PR TITLE
Clearer role headings

### DIFF
--- a/artisan_roles/index.md
+++ b/artisan_roles/index.md
@@ -9,92 +9,77 @@ If you're asking 'Why?', check out the [value stories](./value_stories.html).
 
 Prerequisites for Apprentice
 -------------------------
-As a **prospective Apprentice**\\
+As a **prospective Apprentice**  
 I should exhibit the following behaviors:
-<ul>
-<li>basic technical and soft-skills aptitude</li>
-<li>enthusiasm for learning</li>
-<li>willingness to be coached (healthy ego)</li>
-</ul>
+
+- Basic technical and soft-skills aptitude
+- Enthusiasm for learning
+- Willingness to be coached (healthy ego)
+
 So that I can become an **Apprentice**
 
 Prerequisites for Journeyman (1 year)
 -------------------
-As an **Apprentice**\\
+As an **Apprentice**  
 I should exhibit the following behaviors:
-<ul>
-<li>Proficiency in at least 1 marketable technology</li>
-<li>Aware of basic Pillar Tenets of Software Engineering</li>
-<li>Actively participated on at least one Pillar Project</li>
-</ul>
+
+- Proficiency in at least 1 marketable technology
+- Aware of basic Pillar Tenets of Software Engineering
+- Actively participated on at least one Pillar Project
+
 So that I am eligible to become a **Journeyman**
 
 Prerequisites for Craftsman (5+ years)
 ---------------------
-As a **Journeyman**\\
+As a **Journeyman**  
 I should exhibit the following behaviors:
-<ul>
-<li>proficiency in at least 3 marketable technologies</li>
-<li>actively demonstrating Pillar’s engineering practices</li>
-<li>actively learning team room practices</li>
-<li>actively learning value practices</li>
-<li>actively participated/ing on at least 3 clients</li>
-</ul>
+
+- Proficiency in at least 3 marketable technologies
+- Actively demonstrating Pillar’s engineering practices
+- Actively learning team room practices
+- Actively learning value practices
+- Actively participated/ing on at least 3 clients
+
 So that I am eligible to become a **Craftsman**
 
 Prerequisites for Master Craftsman (7+ years)
 --------------------
-As a **Craftsman**\\
+As a **Craftsman**  
 I should exhibit the following behaviors:
-<ul>
-<li>demonstrable proficiency in at least 6 marketable technologies</li>
-<li>actively integrating engineering practices and value practices</li>
-<li>pay it forward (blogs, open source, speaking engagements, etc)</li>
-<li>organizational development within Pillar
-    <ul>
-    <li>talent</li>
-    <li>content creation</li>
-    <li>growth engagements</li>
-    </ul>
-</li>
-<li>a mentor: have mentored 3/yr of Apprentices and Journeymen
-    <ul>
-    <li>peer references required</li>
-    </ul>
-</li>
-<li>understand the history and rationale for our development practices</li>
-<li>heightened consulting skills
-    <ul>
-    <li>understand what change your client and team are ready for and speak to it appropriately</li>
-    </ul>
-</li>
-<li>high level of emotional intelligence
-    <ul>
-    <li>e.g. identify and manage situations where harassment is an issue</li>
-    </ul>
-</li>
-<li>leading team room practices</li>
-<li>6+ clients</li>
-</ul>
+
+- Demonstrable proficiency in at least 6 marketable technologies
+- Actively integrating engineering practices and value practices
+- Pay it forward (blogs, open source, speaking engagements, etc)
+- Organizational development within Pillar
+    + talent
+    + content creation
+    + growth engagements
+- A mentor: have mentored 3/yr of Apprentices and Journeymen
+    + peer references required
+- Understand the history and rationale for our development practices
+- Heightened consulting skills
+    + Understand what change your client and team are ready for and speak to it appropriately
+- High level of emotional intelligence
+    - e.g. Identify and manage situations where harassment is an issue
+- Leading team room practices
+- 6+ clients
+
 So that I am eligible to become a **Master Craftsman**
 
 Master Craftsman
 ----------------
-As a **Master Craftsman**\\
+As a **Master Craftsman**  
 I should exhibit the following behaviors:
-<ul>
-<li>Know the rules, but more importantly, know when to break them</li>
-<li>leading/innovating engineering practices</li>
-<li>leading/innovating business acumen</li>
-<li>mentor: finding and growing future Master Craftsman</li>
-<li>influencing organizational development</li>
-<li>Maintain the following practice documents:
-    <ul>
-    <li>Pillar Tenets of Software Craftsmanship</li>
-    <li>Pillar’s Value Practices</li>
-    <li>Marketable Skills for Artisans</li>
-    <li>Pillar’s Team Room Practices</li>
-    </ul>
-</li>
-</ul>
+
+- Know the rules, but more importantly, know when to break them
+- Leading/innovating engineering practices
+- Leading/innovating business acumen
+- Mentor: finding and growing future Master Craftsman
+- Influencing organizational development
+- Maintain the following practice documents:
+    + Pillar Tenets of Software Craftsmanship
+    + Pillar’s Value Practices
+    + Marketable Skills for Artisans
+    + Pillar’s Team Room Practices
+
 So that I can maintain and grow my role as a **Master Craftsman**

--- a/artisan_roles/index.md
+++ b/artisan_roles/index.md
@@ -5,7 +5,7 @@ title: Guild Artisan Personas
 
 If you're asking 'Why?', check out the [value stories](./value_stories.html).
 
-> The time frame denoted in parentheses is an average number of years spent at that level
+> The time frame denoted in parentheses is an average number of years spent working to reach that next level
 
 Prerequisites for Apprentice
 -------------------------
@@ -18,7 +18,7 @@ I should exhibit the following behaviors:
 
 So that I can become an **Apprentice**
 
-Prerequisites for Journeyman (1 year)
+Apprentice to Journeyman (1 year)
 -------------------
 As an **Apprentice**  
 I should exhibit the following behaviors:
@@ -29,7 +29,7 @@ I should exhibit the following behaviors:
 
 So that I am eligible to become a **Journeyman**
 
-Prerequisites for Craftsman (5+ years)
+Journeyman to Craftsman (5+ years)
 ---------------------
 As a **Journeyman**  
 I should exhibit the following behaviors:
@@ -42,7 +42,7 @@ I should exhibit the following behaviors:
 
 So that I am eligible to become a **Craftsman**
 
-Prerequisites for Master Craftsman (7+ years)
+Craftsman to Master Craftsman (7+ years)
 --------------------
 As a **Craftsman**  
 I should exhibit the following behaviors:

--- a/artisan_roles/index.md
+++ b/artisan_roles/index.md
@@ -7,7 +7,7 @@ If you're asking 'Why?', check out the [value stories](./value_stories.html).
 
 > The time frame denoted in parentheses is an average number of years spent at that level
 
-Pre Requisites Apprentice
+Prerequisites for Apprentice
 -------------------------
 As a **prospective Apprentice**\\
 I should exhibit the following behaviors:
@@ -18,7 +18,7 @@ I should exhibit the following behaviors:
 </ul>
 So that I can become an **Apprentice**
 
-Apprentice (1 year)
+Prerequisites for Journeyman (1 year)
 -------------------
 As an **Apprentice**\\
 I should exhibit the following behaviors:
@@ -29,7 +29,7 @@ I should exhibit the following behaviors:
 </ul>
 So that I am eligible to become a **Journeyman**
 
-Journeyman (5+ years)
+Prerequisites for Craftsman (5+ years)
 ---------------------
 As a **Journeyman**\\
 I should exhibit the following behaviors:
@@ -41,8 +41,8 @@ I should exhibit the following behaviors:
 <li>actively participated/ing on at least 3 clients</li>
 </ul>
 So that I am eligible to become a **Craftsman**
- 
-Craftsman (7+ years)
+
+Prerequisites for Master Craftsman (7+ years)
 --------------------
 As a **Craftsman**\\
 I should exhibit the following behaviors:
@@ -98,4 +98,3 @@ I should exhibit the following behaviors:
 </li>
 </ul>
 So that I can maintain and grow my role as a **Master Craftsman**
-


### PR DESCRIPTION
Almost everybody I’ve talked to mis-understood the structure of the page at first glance, thinking that the items below each heading were the prerequisites for achieving that level, when in fact they were prereqs for the _next_ level.

Even though the "As a …, so that…" text makes it explicit, the headings need some clarification to make the content easier to grok. In this PR, instead of "Journeyman (5+ years)" they would look like "Journeyman to Craftsman (5+ years)." We could use different style, but it has to be something clearer than what we have now.

The other changes are just to make the markdown easier to read/edit.

One thing to point out is that these sections (even before the heading tweaks) don’t _define_ each level so much as describe how to _move up_ from each level. Not a huge deal, but we might need to clarify things like the page title, value stories, etc.