### PR TITLE
Added Consultant text to Journeyman and Craftsman

### DIFF
--- a/artisan_roles/index.md
+++ b/artisan_roles/index.md
@@ -25,6 +25,7 @@ I should exhibit the following behaviors:
 
 - Proficiency in at least 1 marketable technology
 - Aware of basic Pillar Tenets of Software Engineering
+- Awareness of Consultant responsibilities
 - Actively participated on at least one Pillar Project
 
 So that I am eligible to become a **Journeyman**
@@ -36,6 +37,7 @@ I should exhibit the following behaviors:
 
 - Proficiency in at least 3 marketable technologies
 - Actively demonstrating Pillar’s engineering practices
+- Actively demonstrating Consultant values
 - Actively learning team room practices
 - Actively learning value practices
 - Actively participated/ing on at least 3 clients


### PR DESCRIPTION
I've talked with Guild leaders about starting to emphasize "life as a Consultant" and how it differs from "life as a code slinger." I think having it explicitly in our Guild docs would be great.